### PR TITLE
Use <code> tag to ensure straight quotes.

### DIFF
--- a/_lessons/hand_coded_heat/lesson.md
+++ b/_lessons/hand_coded_heat/lesson.md
@@ -360,7 +360,7 @@ input in the correct units. Take care!
 
 {% include qanda
    question='Determine the command-line to run for our simple science problem?'
-   answer='./heat runame=wall alpha=8.2e-10 lenx=0.25 dx=0.01 dt=100 outi=100 savi=1000 maxt=55800 bc0=233.15 bc1=294.261 ic="const(294.261)"' %}
+   answer='<code>./heat runame=wall alpha=8.2e-10 lenx=0.25 dx=0.01 dt=100 outi=100 savi=1000 maxt=55800 bc0=233.15 bc1=294.261 ic="const(294.261)"</code>' %}
 
 ## Exercise #4: Analyze Results and Do Some Science
 


### PR DESCRIPTION
When solution command is rendered, the straight quotes are getting converted to curly quotes... which causes an issue in the bash interpreter.